### PR TITLE
Fix 'open NT on dir' match behavior of 'no files'

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -107,7 +107,7 @@ autocmd VimEnter * if argc() == 0 && !exists("s:std_in") && v:this_session == ""
 #### How can I open NERDTree automatically when vim starts up on opening a directory?
 ```vim
 autocmd StdinReadPre * let s:std_in=1
-autocmd VimEnter * if argc() == 1 && isdirectory(argv()[0]) && !exists("s:std_in") | exe 'NERDTree' argv()[0] | wincmd p | ene | exe 'cd '.argv()[0] | endif
+autocmd VimEnter * if argc() == 1 && isdirectory(argv()[0]) && !exists("s:std_in") | exe 'NERDTree' argv()[0] | wincmd p | ene | wincmd p | exe 'cd '.argv()[0] | endif
 ```
 
 This window is tab-specific, meaning it's used by all windows in the tab. This trick also prevents NERDTree from hiding when first selecting a file.


### PR DESCRIPTION
If you implement `How can I open a NERDTree automatically when vim starts up if no files were specified?`, you get the NT as the active window, ready for file selection.

However, if you implement `How can I open NERDTree automatically when vim starts up on opening a directory?` (pre change), it makes the blank/empty buffer the active window.

This change modifies the latter to match the former.

### Description of Changes
Closes #  <!-- Issue number this PR addresses. If none, remove this line. -->


---
### New Version Info

#### Author's Instructions
- [ ] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [ ] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merge, tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
